### PR TITLE
Update StreamClient.pm with nosniff header

### DIFF
--- a/web/StreamClient.pm
+++ b/web/StreamClient.pm
@@ -82,6 +82,8 @@ sub call {
 	
 	my $req = Plack::Request->new($env);
 	my $res = $req->new_response(200); # new Plack::Response
+	# FIX Chrome MIME Sniffing with Ubuntu 14.04 with Perl 5.18.x
+	$res->headers([ 'X-Content-Type-Options' => 'nosniff' ]);
 	$res->content_type('text/plain');
 	
 	my $body;


### PR DESCRIPTION
FIX Chrome MIME Sniffing: Ubuntu 14.04 with Perl 5.18.x causing Chrome browser to download some streams (e.g. TLS) instead of displaying, regardless of content-type: text-plain.  Chrome is ignoring stated content type due to some binary bytes in the stream.

REFERENCES: 
https://bugs.chromium.org/p/chromium/issues/detail?id=106150, 
http://stackoverflow.com/questions/9660514/content-type-of-text-plain-causes-browser-to-download-of-file
https://mimesniff.spec.whatwg.org/
